### PR TITLE
basics/tips-and-tricks.md: clarify tab movement between windows to match shortcut title

### DIFF
--- a/src/pages/basics/tips-and-tricks.md
+++ b/src/pages/basics/tips-and-tricks.md
@@ -81,7 +81,7 @@ For the external display to work, Blink needs to be an active window on the iPad
 From iPad OS 13, we have multiple windows support inside Blink, and each window can have infinite tabs. 
 ![Blink Shell Windows](./tips-and-tricks/windows.png)
 
-You can also move windows between iPad and External Display with `Shift + CMD + O` or change focus to it using `CMD + O`.
+You can also move tabs between the iPad window and External Display window with `⇧ Shift + ⌘ Cmd + O` or change focus to the other window using `⌘ Cmd + O`.
 
 ### Keyboard: Separate Keys
 


### PR DESCRIPTION
Also, used `⇧ Shift` and `⌘ Command` in shortcuts. I’d love to unify the shortcut style across docs, and like this pattern I saw in a couple instances of the Blink docs.

I’d also be happy to converge on Apple style: https://support.apple.com/en-us/HT201236 or any other style. Just, you know, so long as we’re moderately consistent.