### PR TITLE
Tune home bar tap documentation

### DIFF
--- a/src/pages/basics/navigation.md
+++ b/src/pages/basics/navigation.md
@@ -25,7 +25,7 @@ Gestures are very important inside Blink. Thanks to them we can enjoy a full scr
 * To create a new shell, you can tap the window with two fingers.
 * Swiping with one finger from side to side will move between active shells.
 * You can control the size of your terminal by pinching the screen.
-* Tapping twice in the iOS Home Bar, or pressing the `CMD` ⌘ key twice, in Software or Hardware keyboards, will open a contextual menu where you can create or close tabs, open Snips, or configure display modes.
+* Tapping twice in the iOS Home Bar (no Software KB), or pressing the `CMD` ⌘ key twice, in Software or Hardware keyboards, will open a contextual menu where you can create or close tabs, open Snips, or configure display modes.
 ![img](./navigation/navigating-blink-shell-contextual-bar.jpg)
 * Tapping and scrolling with a single finger will move the focus to that window and scroll it. If the application supports mouse control, then you will be able to control the pointer that way.
 * Tap and drag to start selection mode.


### PR DESCRIPTION
If software KB is on, we can't capture double tap on home bar.