### PR TITLE
Clarify how `link-files` and `scp` work together

### DIFF
--- a/src/pages/advanced/unix-roundup.md
+++ b/src/pages/advanced/unix-roundup.md
@@ -17,6 +17,7 @@ iOS limits you to a sandbox, but you can make the most of this by linking files 
 Once you've linked the desired folder you're ready to go. Want to make folders in iCloud? No problem,
 
 ```bash
+cd iCloud/
 mkdir docs
 ```
 
@@ -66,7 +67,13 @@ scp file user@remotehost:remotepath
 sftp user@remotehost:remotepath
 ```
 
-In this example, we will transfer a file named `file` to the server `remotehost` with the username of `user` to place it in the `remotepath` folder. `scp` accepts wildcards, allowing the transfer of multiple files at once, but you can also `tar` the files for a better transfer experience. Blink will 
+In this example, we will transfer a file named `file` to the server `remotehost` with the username of `user` to place it in the `remotepath` folder. `scp` accepts wildcards, allowing the transfer of multiple files at once, but you can also `tar` the files for a better transfer experience.
+
+To download a file from the server, run:
+
+```bash
+scp user@remotehost:remotepath link-files-folder/file
+```
 
 Although the `sftp` command in UNIX environments is interactive, Blink Shell uses scp and sftp interchangeably. If you wish to start an interactive session, we have a better solution with our [Files.app integration](/advanced/files-app). This is a fantastic way to browse and open files in a remote Host.
 


### PR DESCRIPTION
The current docs don’t spell out how `link-files` and `scp` work together. This PR clarifies this point and adds an example for the common use case of saving (and later syncing) a local copy of a file from the remote host.